### PR TITLE
Measure code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,5 +78,4 @@ workflows:
             branches:
               only:
                 - master
-                - measure-code-coverage
       - angular_check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,5 +76,7 @@ workflows:
             - java_build
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - measure-code-coverage
       - angular_check

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "java"
-    id "jacoco"
     id "org.springframework.boot" version "1.5.7.RELEASE"
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java"
+    id "jacoco"
     id "org.springframework.boot" version "1.5.7.RELEASE"
 }
 


### PR DESCRIPTION
Add jacoco gralde plugin to measure code coverage. This will also enable coverage reports in SonarQube.