### PR TITLE
fix sonarqube settings

### DIFF
--- a/gradle.d/600-sonarqube.gradle
+++ b/gradle.d/600-sonarqube.gradle
@@ -1,9 +1,10 @@
 sonarqube {
     properties {
-        property "sonar.projectName", "BudgetFreak-${System.env.CIRCLE_BRANCH}"
-        property "sonar.projectKey", "de.budgetfreak:budgetfreak-${System.env.CIRCLE_BRANCH}"
+        property "sonar.projectName", "BudgetFreak"
+        property "sonar.projectKey", "de.budgetfreak:budgetfreak"
         property "sonar.organization", "budgetfreak-github"
+        property "sonar.branch.name", "${System.env.CIRCLE_BRANCH}"
         property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.login", "${System.getenv().SONAR_LOGIN}"
+        property "sonar.login", "${System.env.SONAR_LOGIN}"
     }
 }


### PR DESCRIPTION
Remove the "master"-postfix from SonarQube settings (e.g. projectKey).

This will enable branch analysis because the branch name will not be published as a part of the projectKey.