### PR TITLE
Configure metamodel generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ gradle-app.setting
 
 # JRebel
 **/rebel.xml
+
+# Generated sources
+**/src/main/generated

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,13 +3,14 @@
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.warning.mode=all
-org.gradle.jvmargs='-Dfile.encoding=UTF-8'  
+org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 #
 # application
 version_spring_boot=2.0.2.RELEASE
 version_spring_boot_dependency_management=1.0.5.RELEASE
 version_flyway=5.0.7
 version_commons_lang=3.7
+version_jpamodelgen=5.2.17.Final
 #
 # test
 version_assertj=3.10.0
@@ -18,4 +19,3 @@ version_flyway_spring_test=5.0.0
 #
 # database
 version_h2=1.4.197
-version_jpamodelgen=5.2.6.Final

--- a/server/budgeting/src/main/java/de/budgetfreak/budgeting/specification/CategorySpecifications.java
+++ b/server/budgeting/src/main/java/de/budgetfreak/budgeting/specification/CategorySpecifications.java
@@ -1,6 +1,8 @@
 package de.budgetfreak.budgeting.specification;
 
 import de.budgetfreak.budgeting.domain.Category;
+import de.budgetfreak.budgeting.domain.Category_;
+import de.budgetfreak.budgeting.domain.MasterCategory_;
 import de.budgetfreak.usermanagement.domain.User;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
@@ -12,6 +14,6 @@ import org.springframework.stereotype.Component;
 public class CategorySpecifications {
 
     public Specification<Category> byUser(User user) {
-        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("masterCategory").get("user"), user);
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get(Category_.masterCategory).get(MasterCategory_.user), user);
     }
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -44,17 +44,15 @@ subprojects {
 
     compileJava {
         doFirst {
-            // delete any generated sources from IntelliJ
-            removeGeneratedMetamodel.execute()
-//            generatedSourcesDir.mkdirs()
+            delete generatedSourcesDir
+            mkdir generatedSourcesDir
         }
-//        options.compilerArgs += ['-s', generatedSourcesDir]
+        options.compilerArgs += ['-s', generatedSourcesDir]
     }
 
     task removeGeneratedMetamodel(type: Delete) {
-        generatedSourcesDir.deleteDir()
+        delete generatedSourcesDir
     }
-//
     clean.dependsOn(removeGeneratedMetamodel)
 
     dependencies {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,6 +27,36 @@ subprojects {
         options.encoding = "UTF-8"
     }
 
+    ext {
+        generatedSourcesDir = file("src/main/generated")
+    }
+
+    sourceSets {
+        main {
+            java {
+                srcDir 'src/main/java'
+                // This directory only contains generated sources by builds from ItelliJ. It should always be empty and
+                // is ignored in version control.
+                srcDir 'src/main/generated'
+            }
+        }
+    }
+
+    compileJava {
+        doFirst {
+            // delete any generated sources from IntelliJ
+            removeGeneratedMetamodel.execute()
+//            generatedSourcesDir.mkdirs()
+        }
+//        options.compilerArgs += ['-s', generatedSourcesDir]
+    }
+
+    task removeGeneratedMetamodel(type: Delete) {
+        generatedSourcesDir.deleteDir()
+    }
+//
+    clean.dependsOn(removeGeneratedMetamodel)
+
     dependencies {
         compile(
                 "org.springframework.boot:spring-boot-starter-data-jpa",
@@ -36,9 +66,12 @@ subprojects {
                 "org.apache.commons:commons-lang3:${version_commons_lang}",
         )
 
+        annotationProcessor(
+                "org.hibernate:hibernate-jpamodelgen:${version_jpamodelgen}",
+        )
+
         compileOnly(
                 "org.hibernate:hibernate-jpamodelgen:${version_jpamodelgen}",
-
         )
 
         runtime(


### PR DESCRIPTION
Metamodels are generated by Gralde and IntelliJ. Both put the metamodels to `src/main/generated`. That directory is also used as sources root in IntelliJ.